### PR TITLE
Change approach to save files to make io replacement possible

### DIFF
--- a/lib/rspreadsheet.rb
+++ b/lib/rspreadsheet.rb
@@ -1,18 +1,81 @@
 require 'rspreadsheet/version'
+require "rspreadsheet/document"
 require 'rspreadsheet/workbook'
 require 'rspreadsheet/worksheet'
 require 'helpers/class_extensions'
 require 'helpers/configuration'
 
+
+# @example
+#
+#   # Create new document
+#   document = ::Rspreadsheet.create_document
+#   workbook = document.workbook
+#
+#   # Open existead document
+#   document = ::Rspreadsheet.open_document(path_to_the_spreadsheet_file)
+#   workbook = document.workbook
+#
+#   # Save document to the file.
+#   ::Rspreadsheet.save_document(document, path_to_a_new_spreadsheet_file)
 module Rspreadsheet
   extend Configuration
   define_setting :raise_on_negative_coordinates, true
 
-  # makes creating new workbooks as easy as `Rspreadsheet.new` or `Rspreadsheet.open('filename.ods')
-  def self.new(filename=nil)
-    Workbook.new(filename)
-  end  
-  def self.open(filename)
-    Workbook.new(filename)
+
+  class << self
+    # @return [::Rspreadsheet::Document]
+    def create_document
+      document          = ::Rspreadsheet::Document.new
+      document.workbook = ::Rspreadsheet::Workbook.new
+
+      document.build_zip_input_stream_from_file(::Rspreadsheet::Document::TEMPLATE_FILE) do |stream|
+        document.workbook.load(stream)
+      end
+
+      document
+    end
+
+    # @param file_path [::Rspreadsheet::Document] file path to the document
+    #   file which should be opened
+    #
+    # @return [::Rspreadsheet::Document]
+    def open_document(file_path)
+      document          = ::Rspreadsheet::Document.new
+      document.workbook = ::Rspreadsheet::Workbook.new
+
+      document.build_zip_input_stream_from_file(file_path) do |stream|
+        document.workbook.load(stream)
+      end
+
+      document
+    end
+
+    # Saves the worksheet. Optionally you can provide new filename.
+    #
+    # @param document  [::Rspreadsheet::Document]
+    # @param file_path [String, Pathname] (nil) file path to file where document
+    #   will be saved
+    #
+    # @return [::Rspreadsheet::Document]
+    #
+    # @raise [::RuntimeError] when given document has no file path and path to
+    #   save file has not been given
+    # @raise [::RuntimeError] when by given file_path or document's file_path
+    #   file already exists.
+    def save_document(document, file_path = nil)
+      file_save_path = file_path || document.file_path
+      unless file_save_path
+        raise "New file should be named on first save."
+      end
+
+      if ::File.exists?(file_save_path)
+        raise "File at path '#{file_save_path}' already exists."
+      end
+
+      ::File.new(file_save_path) do |ods_file_io|
+        document.save(ods_file_io)
+      end
+    end
   end
 end

--- a/lib/rspreadsheet/document.rb
+++ b/lib/rspreadsheet/document.rb
@@ -1,0 +1,66 @@
+require "zip"
+
+
+# This is an ODS container which is used to serialize document.
+class ::Rspreadsheet::Document
+  # @!attribute MIME_TYPE [r]
+  #   @return [String]
+  MIME_TYPE = "application/vnd.oasis.opendocument.spreadsheet".freeze
+
+  # @!attribute FILE_EXTENSION [r]
+  #   @return [String]
+  FILE_EXTENSION = "ods".freeze
+
+  # @!attribute TEMPLATE_FILE
+  #   @return [Pathname]
+  TEMPLATE_FILE = Pathname.new(__dir__).join("empty_file_template.ods").freeze
+
+  # @!attribute CONTENT_FILE_NAME
+  #   @return [String]
+  CONTENT_FILE_NAME = "content.xml".freeze
+
+
+  # @!attribute file_path
+  #   @return [String, Path]
+  attr_accessor \
+    :file_path,
+    :workbook,
+    :mime_type,
+    :file_extension
+
+
+  # @return [void]
+  def initialize
+    @file_path = @workbook = nil
+
+    @mime_type      = MIME_TYPE
+    @file_extension = FILE_EXTENSION
+  end
+
+  # @return [void]
+  def build_zip_input_stream_from_file(file_path)
+    ::Zip::File.open(file_path) do |zip|
+      yield zip.get_input_stream(CONTENT_FILE_NAME)
+    end
+  end
+
+  # @param io [IO] (StringIO)
+  #
+  # @return [IO]
+  def save(io = ::StringIO.new)
+    ::Zip::OutputStream.write_buffer(io) do |output|
+      ::Zip::File.open(TEMPLATE_FILE) do |input|
+        input.
+          select { |entry| entry.file? }.
+          select { |entry| entry.name != CONTENT_FILE_NAME }.
+          each do |entry|
+            output.put_next_entry(entry.name)
+            output.write(entry.get_input_stream.read)
+          end
+      end
+
+      output.put_next_entry(CONTENT_FILE_NAME)
+      @workbook.store(output)
+    end
+  end
+end


### PR DESCRIPTION
# Overview

Dirty sketch of how we can rework architecture of file processing to make possible storing documents into `IO` instances which is useful for in case of library usage in web frameworks.
# Related issues
- [Access to document octet string outside of ::Rspreadsheet::Workbook class without file creation.](https://github.com/gorn/rspreadsheet/issues/7)
# API interface compatibility
- This pull request brakes API interfaces for follow classes and modules:
  - [`::Rspreadsheet`](https://github.com/gorn/rspreadsheet/compare/master...zekefast:change_approach_to_save_files_to_make_io_replacement_possible?expand=1#diff-519333f678a7f8b4021904afbbaaf3f2L7)
  - [`::Rspreadsheet::Workbook`](https://github.com/gorn/rspreadsheet/compare/master...zekefast:change_approach_to_save_files_to_make_io_replacement_possible?expand=1#diff-ffc48b9f42c3adf373b36e4fa7787ac1R5)
# Warning

This is just WIP example. It has not been precisely tested and test for code provided in it have not been fixed nor new unit tests have been written.

In case there is a possibility to merge that PR I can clean up the code here and write proper unit tests. But first let discussion going...
