### PR TITLE
not using libxml-ruby 2.9.0 to avoid segmentation faults

### DIFF
--- a/rspreadsheet.gemspec
+++ b/rspreadsheet.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   
   # runtime dependencies
   unless package_natively_installed?('ruby-libxml')
-    spec.add_runtime_dependency 'libxml-ruby', '~>2.7'   # parsing XML files
+    spec.add_runtime_dependency 'libxml-ruby', '2.8'   # parsing XML files
   end
   spec.add_runtime_dependency 'rubyzip', '~>1.1'       # opening zip files
   spec.add_runtime_dependency 'andand', '~>1.3'


### PR DESCRIPTION
Using libxml-ruby 2.9.0 I estimate there was a segmentation fault every run of rspec out of three.

Using libxml-ruby 2.8.0 I run all the rspec tests without error 200 times.

Hopefully this fix will also avoid errors in travis.