### PR TITLE
Updating to libxml-ruby 3.0 and fixes #32

### DIFF
--- a/rspreadsheet.gemspec
+++ b/rspreadsheet.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   # runtime dependencies
   unless package_natively_installed?('ruby-libxml')
-    spec.add_runtime_dependency 'libxml-ruby', '2.8'   # parsing XML files
+    spec.add_runtime_dependency 'libxml-ruby', '3.0'   # parsing XML files
   end
   spec.add_runtime_dependency 'rubyzip', '~>1.1'       # opening zip files
   spec.add_runtime_dependency 'andand', '~>1.3'

--- a/spec/class_extensions_spec.rb
+++ b/spec/class_extensions_spec.rb
@@ -21,8 +21,8 @@ if RUBY_VERSION > '2.1'
       @m2 = LibXML::XML::Node.new('a')
     end
     it 'can compare nodes' do
-      @n.should == @m
-      @n.should_not == @m2
+      @n.to_s.should == @m.to_s
+      @n.to_s.should_not == @m2.to_s
     end
     it 'has correct elements' do
   #     raise @n.first_diff(@m).inspect

--- a/spec/io_spec.rb
+++ b/spec/io_spec.rb
@@ -71,6 +71,5 @@ end
 def xmls_should_be_identical(xml1,xml2) 
   xml2.root.first_diff(xml1.root).should be_nil
   xml1.root.first_diff(xml2.root).should be_nil
-  
-  xml1.root.should == xml2.root
+  xml1.root.to_s.should == xml2.root.to_s
 end

--- a/spec/rspreadsheet_spec.rb
+++ b/spec/rspreadsheet_spec.rb
@@ -48,8 +48,7 @@ describe Rspreadsheet do
     
     @content_xml2.root.first_diff(@content_xml1.root).should be_nil
     @content_xml1.root.first_diff(@content_xml2.root).should be_nil
-    
-    @content_xml1.root.should == @content_xml2.root
+    @content_xml1.root.to_s.should == @content_xml2.root.to_s
   end
 
   it 'when open and save file modified, than the file is different' do


### PR DESCRIPTION
According to https://github.com/xml4r/libxml-ruby/blob/master/HISTORY:

* Change XML::Node#eql? API.  Nodes are now considered equal only if they wrap the same underlying
  libxml node.  Previously, they would also be considered equal if they contained the same content
  (Charlie Savage)

So comparing the string representation would tell if the structure of two nodes is the same.