### PR TITLE
make workbook behave consistent with other types

### DIFF
--- a/lib/rspreadsheet/workbook.rb
+++ b/lib/rspreadsheet/workbook.rb
@@ -52,10 +52,17 @@ class Workbook
   end
   alias :sheet :worksheet
 
-  # return Array of all worksheets in the document
-  def worksheets
-    @worksheets
-  end
+	# @param [Integer,String]
+  # if index_or_name is provided, calls worksheet
+	# @return Array of all worksheets in the document
+	def worksheets(index_or_name=nil)
+		case index_or_name
+  		when nil
+				@worksheets
+			else
+  			worksheet(index_or_name)
+		end
+	end
 
   alias :sheets :worksheets
   def [](index_or_name); self.worksheets(index_or_name) end

--- a/lib/rspreadsheet/workbook.rb
+++ b/lib/rspreadsheet/workbook.rb
@@ -52,17 +52,17 @@ class Workbook
   end
   alias :sheet :worksheet
 
-	# @param [Integer,String]
+  # @param [Integer,String]
   # if index_or_name is provided, calls worksheet
-	# @return Array of all worksheets in the document
-	def worksheets(index_or_name=nil)
-		case index_or_name
-  		when nil
-				@worksheets
-			else
-  			worksheet(index_or_name)
-		end
-	end
+  # @return Array of all worksheets in the document
+  def worksheets(index_or_name=nil)
+    case index_or_name
+      when nil
+        @worksheets
+      else
+        worksheet(index_or_name)
+    end
+  end
 
   alias :sheets :worksheets
   def [](index_or_name); self.worksheets(index_or_name) end

--- a/lib/rspreadsheet/workbook.rb
+++ b/lib/rspreadsheet/workbook.rb
@@ -2,32 +2,41 @@ require 'zip'
 require 'libxml'
 
 module Rspreadsheet
-    
+
 class Workbook
   attr_reader :filename
   attr_reader :xmlnode # debug
   def xmldoc; @xmlnode.doc end
-  
+
   #@!group Worksheet methods
   def create_worksheet_from_node(source_node)
     sheet = Worksheet.new(source_node,self)
     register_worksheet(sheet)
     return sheet
   end
+
   def create_worksheet(name = "Sheet#{worksheets_count+1}")
     sheet = Worksheet.new(name,self)
     register_worksheet(sheet)
     return sheet
   end
-  alias :add_worksheet :create_worksheet 
+  alias :add_worksheet :create_worksheet
+
   # @return [Integer] number of sheets in the workbook
-  def worksheets_count; @worksheets.length end
+  def worksheets_count
+    @worksheets.length
+  end
   alias :worksheet_count :worksheets_count
+  alias :size :worksheets_count
+
   # @return [String] names of sheets in the workbook
-  def worksheet_names; @worksheets.collect{ |ws| ws.name } end
+  def worksheet_names
+    @worksheets.collect{ |ws| ws.name }
+  end
+
   # @param [Integer,String]
   # @return [Worksheet] worksheet with given index or name
-  def worksheets(index_or_name)
+  def worksheet(index_or_name)
     case index_or_name
       when Integer then begin
         case index_or_name
@@ -41,18 +50,28 @@ class Workbook
       else raise 'method worksheets requires Integer index of the sheet or its String name'
     end
   end
-  alias :worksheet :worksheets
-  alias :sheet :worksheets
+  alias :sheet :worksheet
+
+  # return Array of all worksheets in the document
+  def worksheets
+    @worksheets
+  end
+
   alias :sheets :worksheets
   def [](index_or_name); self.worksheets(index_or_name) end
   #@!group Loading and saving related methods
-  
+
   # @return Mime of the file
-  def mime; 'application/vnd.oasis.opendocument.spreadsheet'.freeze end
+  def mime
+    'application/vnd.oasis.opendocument.spreadsheet'.freeze
+  end
+
   # @return [String] Prefered file extension
-  def mime_preferred_extension; 'ods'.freeze end
+  def mime_preferred_extension
+    'ods'.freeze
+  end
   alias :mime_default_extension :mime_preferred_extension
-  
+
   def initialize(afilename=nil)
     @worksheets=[]
     @filename = afilename
@@ -63,7 +82,7 @@ class Workbook
     @xmlnode.find('./table:table').each do |node|
       create_worksheet_from_node(node)
     end
-  end  
+  end
 
   # @param [String] Optional new filename
   # Saves the worksheet. Optionally you can provide new filename or IO stream to which the file should be saved.
@@ -93,7 +112,7 @@ class Workbook
   def to_io
     WorkbookIO.new(self)
   end
-  
+
   def write_ods_to_io(io)
     if @filename.nil?
       Zip::File.open(TEMPLATE_FILE_NAME) do |empty_template_zip|         # open empty_template file
@@ -107,21 +126,21 @@ class Workbook
       end
     end
   end
-  
+
   def flat_format?; false end
   def normal_format?; true end
 
-  private 
+  private
 
   def update_zip_manifest_and_content_xml(input_zip,output_zip)
     update_manifest_xml(input_zip,output_zip)
     update_content_xml(output_zip)
   end
-  
+
   def update_content_xml(zip)
     save_entry_to_zip(zip,CONTENT_FILE_NAME,@content_xml.to_s(indent: false))
   end
-    
+
   def update_manifest_xml(input_zip,output_zip)
     # read manifest
     @manifest_xml = LibXML::XML::Document.io input_zip.get_input_stream(MANIFEST_FILE_NAME)
@@ -138,10 +157,10 @@ class Workbook
           end
           raise 'Could not set up internal_filename correctly.' if @ifname.nil?
           raise 'This should not happen' if image.original_filename.nil?
-          
+
           # save it to zip file
           save_entry_to_zip(output_zip, @ifname, File.open(image.original_filename,'r').read)
-          
+
           # make sure it is in manifest
           if @manifest_xml.find("//manifest:file-entry[@manifest:full-path='#{@ifname}']").empty?
             node = Tools.prepare_ns_node('manifest','file-entry')
@@ -149,24 +168,24 @@ class Workbook
             Tools.set_ns_attribute(node,'manifest','media-type',image.mime)
             @manifest_xml.find_first("//manifest:manifest") << node
             modified = true
-          end  
+          end
         end
       end
     end
 
     # write manifest if it was modified
-    save_entry_to_zip(output_zip, MANIFEST_FILE_NAME, 
+    save_entry_to_zip(output_zip, MANIFEST_FILE_NAME,
                       @manifest_xml.to_s) if modified
   end
-  
+
   def copy_internally_without_content(input_zip,output_zip)
     input_zip.each do |entry|
-      next unless entry.file? 
-      next if entry.name == CONTENT_FILE_NAME 
+      next unless entry.file?
+      next if entry.name == CONTENT_FILE_NAME
       save_entry_to_zip(output_zip, entry.name, entry.get_input_stream.read)
     end
   end
-  
+
   def save_entry_to_zip(zip,internal_filename,contents)
     if zip.kind_of? Zip::File
       zip.get_output_stream(internal_filename) do  |f|
@@ -177,7 +196,7 @@ class Workbook
       zip.write(contents)
     end
   end
-    
+
   CONTENT_FILE_NAME = 'content.xml'
   MANIFEST_FILE_NAME = 'META-INF/manifest.xml'
   TEMPLATE_FILE_NAME = (File.dirname(__FILE__)+'/empty_file_template.ods').freeze
@@ -186,7 +205,7 @@ class Workbook
     @worksheets[index-1]=worksheet
     @xmlnode << worksheet.xmlnode if worksheet.xmlnode.doc != @xmlnode.doc
   end
-      
+
 end
 
 class WorkbookFlat < Workbook
@@ -217,13 +236,13 @@ class WorkbookFlat < Workbook
   end
   alias :save_to_io  :save
   alias :save_as :save
-  
+
   def flat_format?; true end
   def normal_format?; false end
 
-  private 
-  FLAT_TEMPLATE_FILE_NAME = (File.dirname(__FILE__)+'/empty_file_template.fods').freeze  
-    
+  private
+  FLAT_TEMPLATE_FILE_NAME = (File.dirname(__FILE__)+'/empty_file_template.fods').freeze
+
 end
 
 class WorkbookIO

--- a/spec/workbook_spec.rb
+++ b/spec/workbook_spec.rb
@@ -4,10 +4,12 @@ describe Rspreadsheet::Workbook do
   it 'has correct number of sheets' do
     book = Rspreadsheet::Workbook.new($test_filename)
     book.worksheets_count.should == 1
+    book.size.should == 1
     book.worksheets(0).should be_nil
     book.worksheets(1).should be_kind_of(Rspreadsheet::Worksheet)
     book.worksheets(2).should be_nil
-    book.worksheets(nil).should be_nil
+    book.worksheets(nil).should_not be_nil
+    book.worksheet(nil).should be_nil
   end
   it 'freshly created has correctly namespaced xmlnode' do
     @xmlnode = Rspreadsheet::Workbook.new.xmlnode
@@ -38,7 +40,7 @@ describe Rspreadsheet::Workbook do
     book.create_worksheet('test')
     book.worksheets('test').should eq book.worksheets(1)
     book.create_worksheet('another')
-    book.worksheets('another').should eq book.worksheets(2)    
+    book.worksheets('another').should eq book.worksheets(2)
   end
   it 'can access sheets with brief syntax' do
     book = Rspreadsheet::Workbook.new
@@ -70,7 +72,7 @@ describe Rspreadsheet::Workbook do
     book = Rspreadsheet::Workbook.new
     expect { book.worksheet(Array.new()) }.to raise_error
   end
-end 
+end
 
 
 


### PR DESCRIPTION
I noticed that there's an inconsistency with the way you can access worksheets from a workbook object.
I made a couple of changes to workbook so:

- it responds to .size (as alias to :worksheets_count)
- .worksheets returns an array with all worksheets in the book; if provided with a parameter it will fallback to worksheet(i) to avoid breaking spec.

